### PR TITLE
fix: update node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -366,14 +366,6 @@
         "esutils": "2.0.2"
       }
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -783,7 +775,8 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.7",
@@ -972,11 +965,6 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1132,13 +1120,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
+      "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "bignumber.js": "^5.0.0",
     "debug": "^3.1.0",
     "ilp-protocol-psk2": "^0.3.0",
-    "node-fetch": "^1.7.3"
+    "node-fetch": "^2.1.1"
   }
 }


### PR DESCRIPTION
The old version of node-fetch didn't properly support `Content-Length`'s of request body `Buffer`s.

[unhash-server](https://github.com/justmoon/unhash-server/blob/c38618596b3e92440975db6cc5a567d1355e1e39/index.js#L51) needs the `Content-Length` to calculate the price.