### PR TITLE
Add support for STREAM payment method in HTTP-ILP

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ const base64url = buffer => buffer.toString('base64')
 
 const PSK_IDENTIFIER = 'interledger-psk'
 const PSK_2_IDENTIFIER = 'interledger-psk2'
+const STREAM_IDENTIFIER = 'interledger-stream'
 const handlePsk2Request = require('./src/psk2')
+const handleStreamRequest = require('./src/stream')
 
 async function ilpFetch (url, _opts) {
   // Generate the payment token to go along with our requests
@@ -33,11 +35,8 @@ async function ilpFetch (url, _opts) {
     return firstTry
   }
 
-  const { maxPrice, plugin } = opts
-
-  if (!plugin) {
-    throw new Error('opts.plugin must be specified on paid request')
-  }
+  const maxPrice = opts.maxPrice
+  const plugin = opts.plugin || require('ilp-plugin')()
 
   if (!maxPrice) {
     throw new Error('opts.maxPrice must be specified on paid request')
@@ -53,6 +52,11 @@ async function ilpFetch (url, _opts) {
     case PSK_2_IDENTIFIER:
       debug('using PSK2 handler.')
       handler = handlePsk2Request
+      break
+
+    case STREAM_IDENTIFIER:
+      debug('using STREAM handler.')
+      handler = handleStreamRequest
       break
 
     case PSK_IDENTIFIER:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "9.6.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
+      "integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -181,6 +186,11 @@
           "dev": true
         }
       }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -614,6 +624,11 @@
       "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI=",
       "dev": true
     },
+    "extensible-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
+    },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
@@ -861,6 +876,58 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+        }
+      }
+    },
+    "ilp-protocol-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-stream/-/ilp-protocol-stream-1.0.0.tgz",
+      "integrity": "sha512-jn8QZ76AkGiCiAQ7IOv+Yx211KSjBrOztqBTshOmoITM85hn49Jn1mctW+053yV9x8QOmuP4Q0qvwwC4a9Z/pQ==",
+      "requires": {
+        "@types/node": "9.6.18",
+        "bignumber.js": "6.0.0",
+        "debug": "3.1.0",
+        "ilp-packet": "2.2.0",
+        "ilp-protocol-ildcp": "1.0.0",
+        "oer-utils": "2.0.1",
+        "source-map-support": "0.5.6"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+          "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
+        },
+        "ilp-packet": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+          "requires": {
+            "bignumber.js": "5.0.0",
+            "extensible-error": "1.0.2",
+            "long": "3.2.0",
+            "oer-utils": "1.3.4"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+              "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+            },
+            "oer-utils": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
+              "integrity": "sha1-sqmtvJK8GRVaKgDwRWg9Hm1KyCM="
+            }
+          }
+        },
+        "oer-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-2.0.1.tgz",
+          "integrity": "sha512-9m3lctkkc/hofsfw76ZQrsIQmenQcC8MggqRP3aPdImYBObywZUCIEXcXAzekas5UpwMAdy7WT0/aHLoDo8PcQ==",
+          "requires": {
+            "bignumber.js": "6.0.0"
+          }
         }
       }
     },
@@ -1469,6 +1536,20 @@
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "requires": {
+        "buffer-from": "1.0.0",
+        "source-map": "0.6.1"
       }
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bignumber.js": "^5.0.0",
     "debug": "^3.1.0",
     "ilp-protocol-psk2": "^0.3.0",
+    "ilp-protocol-stream": "^1.0.0",
     "node-fetch": "^2.1.1"
   }
 }

--- a/src/stream.js
+++ b/src/stream.js
@@ -22,7 +22,8 @@ async function streamPayment ({
   const stream = connection.createStream()
   stream.setSendMax(opts.maxPrice)
 
-  await new Promise(resolve => setTimeout(resolve, 100))
+  await new Promise(resolve => stream.on('data', resolve))
+
   return fetch(url, opts)
 }
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,0 +1,29 @@
+const { createConnection } = require('ilp-protocol-stream')
+const debug = require('debug')('ilp-fetch:stream')
+const fetch = require('node-fetch')
+
+async function streamPayment ({
+  url,
+  opts,
+  payParams,
+  plugin,
+  payToken
+}) {
+  const [ destinationAccount, _sharedSecret ] = payParams
+  debug('streaming via STREAM. destination=' + destinationAccount)
+
+  const sharedSecret = Buffer.from(_sharedSecret, 'base64')
+  const connection = await createConnection({
+    plugin,
+    destinationAccount,
+    sharedSecret
+  })  
+
+  const stream = connection.createStream()
+  stream.setSendMax(opts.maxPrice)
+
+  await new Promise(resolve => setTimeout(resolve, 100))
+  return fetch(url, opts)
+}
+
+module.exports = streamPayment

--- a/src/stream.js
+++ b/src/stream.js
@@ -24,7 +24,13 @@ async function streamPayment ({
 
   await new Promise(resolve => stream.on('data', resolve))
 
-  return fetch(url, opts)
+  const result = await fetch(url, opts)
+
+  if (stream.isOpen()) {
+    stream.end()
+  }
+
+  return result
 }
 
 module.exports = streamPayment

--- a/test.js
+++ b/test.js
@@ -1,13 +1,10 @@
-const plugin = require('ilp-plugin')()
 const fetch = require('.')
 
-fetch('https://alpha.unhash.io', {
-  plugin,
-  maxPrice: 100,
-  method: 'POST',
-  body: 'hello world'
+fetch('http://localhost:8090', {
+  maxPrice: 10000,
+  method: 'GET'
 })
-  .then(r => r.json())
+  .then(r => r.text())
   .then(json => {
     console.log('json response:', json)
     process.exit(0)


### PR DESCRIPTION
The STREAM payment method:

- Queries the endpoint once with the payment token and gets a 402
- Uses details from `Pay` header to establish STREAM connection
- Creates a stream on the STREAM connection and sets the sendMax to the max price
- Waits for the other side to acknowledge the stream by sending a chunk of data
- Retries the fetch while keeping the stream open
- Closes the stream when the fetch result comes back
- returns the fetch result