### PR TITLE
Feat: expose final price

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ async function ilpFetch (url, _opts) {
   // required.
   if (firstTry.status !== 402) {
     debug('request is not paid. returning result.')
+    firstTry.price = '0'
     return firstTry
   }
 

--- a/src/psk2.js
+++ b/src/psk2.js
@@ -28,6 +28,7 @@ async function streamPayment ({
     .then((res) => {
       debug('streaming request success.')
       resolved = true
+      res.price = String(total)
       return res
     })
     .catch((e) => {

--- a/src/stream.js
+++ b/src/stream.js
@@ -30,6 +30,7 @@ async function streamPayment ({
     stream.end()
   }
 
+  result.price = stream.totalSent
   return result
 }
 


### PR DESCRIPTION
- If the request did not require payment, price is set to `0`
- If the request used PSK2, price is set to the total of all chunk prices
- If the request used STREAM, price is set to the total sent on the stream